### PR TITLE
Fix warnings about overlapping group allocations

### DIFF
--- a/sonic.asm
+++ b/sonic.asm
@@ -13,7 +13,8 @@
 		opt	w+					; print warnings
 		opt	m+					; do not expand macros - if enabled, this can break assembling
 
-Main:		section	org(0)
+Main: 	group org(0)
+		section MainProgram,Main
 
 		include "Mega Drive.asm"
 		include "Macros - More CPUs.asm"

--- a/sound/Sound Data.asm
+++ b/sound/Sound Data.asm
@@ -160,7 +160,7 @@ SoundPriorities:
 
 DACDriver:
 		pushs				; store section information for Main
-DACZ80:	section	org(0), file("sound/DAC Driver.unc") ; create new section for the sound driver
+DACZ80:	section	org(0), file("sound/DAC Driver.unc"), over(Main) ; create new section for the sound driver
 		cpu Z80
 		include "sound/DAC Driver.asm"	; include the actual DAC driver
 		
@@ -168,7 +168,7 @@ DACZ80:	section	org(0), file("sound/DAC Driver.unc") ; create new section for th
 		pops 							; go back to the main section
 		pushs	
 
-MergeCode:	section org(0), file("sound/DAC Driver Offset & Size.dat")	; create settings file for storing info about how to merge things
+MergeCode:	section org(0), file("sound/DAC Driver Offset & Size.dat"), over(Main)	; create settings file for storing info about how to merge things
 		dc.l offset(DACDriver),Z80_Space		; store info about location of file and size available
 		pops									; go back to main section
 


### PR DESCRIPTION
A very small tweak to my work on the DAC driver assembly. I finally figured out how the 'over' directive works, and have implemented it for the DAC Driver and MergeCode groups. This fixes the assembler warning about overlapping group allocations when building.